### PR TITLE
map: Add window message for parent window size

### DIFF
--- a/map/map.js
+++ b/map/map.js
@@ -316,6 +316,10 @@ window.onload = function () {
     }
   }
 
+
+  // Post to any parent window the preferred height. Used when the page is an iframe
+  window.parent.postMessage({ heightRequest: window.outerHeight }, "*");
+
   if (window.location.search){
     const urlParams = new URLSearchParams(window.location.search);
     const lat = urlParams.get("lat");


### PR DESCRIPTION
This allows a parent window to listen to a size request so that the
if there is a container it can resize to the natural height of the page.